### PR TITLE
Fix paths in installation instructions

### DIFF
--- a/docs/install.html
+++ b/docs/install.html
@@ -66,13 +66,13 @@
 https://unpkg.com/botui/build/botui.min.css
 
 // default theme - you can create your own theme
-https://unpkg.com/botui/botui/build/botui-theme-default.css
+https://unpkg.com/botui/build/botui-theme-default.css
 
 // Vue - BotUI requires Vue to be present in page
 https://cdn.jsdelivr.net/vue/latest/vue.min.js
 
 // BotUI - main file
-https://unpkg.com/botui/botui/build/botui.min.js
+https://unpkg.com/botui/build/botui.min.js
 
 </code></pre>
 <h3 id="npm-install">NPM Install</h3>

--- a/md-docs/install.md
+++ b/md-docs/install.md
@@ -11,13 +11,13 @@ A BotUI page requires following files. You can use these links directly in your 
 https://unpkg.com/botui/build/botui.min.css
 
 // default theme - you can create your own theme
-https://unpkg.com/botui/botui/build/botui-theme-default.css
+https://unpkg.com/botui/build/botui-theme-default.css
 
 // Vue - BotUI requires Vue to be present in page
 https://cdn.jsdelivr.net/vue/latest/vue.min.js
 
 // BotUI - main file
-https://unpkg.com/botui/botui/build/botui.min.js
+https://unpkg.com/botui/build/botui.min.js
 
 ```
 


### PR DESCRIPTION
I got a 404 for these, seems to have one extra `botui` in them?