### PR TITLE
Fix typo in guide of select

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -157,7 +157,7 @@ Here&apos;s how to show a loading message:</p>
   <span class="hljs-attr">action</span>: {
       <span class="hljs-attr">placeholder</span> : <span class="pl-s">&quot;Select Language&quot;</span>, 
       <span class="hljs-attr">value</span>: <span class="pl-s">&apos;TR&apos;</span>, <span class="pl-c">// Selected value or selected object. Example: {value: &quot;TR&quot;, text : &quot;T&#xFC;rk&#xE7;e&quot; }</span>
-      searchselect : <span class="pl-c1">true</span> <span class="pl-c">// Default: true, false for standart dropdown</span>
+      searchselect : <span class="pl-c1">true</span>, <span class="pl-c">// Default: true, false for standart dropdown</span>
       label : <span class="pl-s">&apos;text&apos;</span>, <span class="pl-c">// dropdown label variable</span>
       options : [
                       {<span class="hljs-attr">value</span>: <span class="pl-s">&quot;EN&quot;</span>, <span class="hljs-attr">text</span> : <span class="pl-s">&quot;English&quot;</span> },

--- a/md-docs/guide.md
+++ b/md-docs/guide.md
@@ -132,7 +132,7 @@ botui.action.select({
   action: {
       placeholder : "Select Language", 
       value: 'TR', // Selected value or selected object. Example: {value: "TR", text : "Türkçe" }
-      searchselect : true // Default: true, false for standart dropdown
+      searchselect : true, // Default: true, false for standart dropdown
       label : 'text', // dropdown label variable
       options : [
                       {value: "EN", text : "English" },


### PR DESCRIPTION
I fixed typo about "botui.action.select".